### PR TITLE
Appdata related patch

### DIFF
--- a/data/io.github.mrvladus.List.metainfo.xml.in.in
+++ b/data/io.github.mrvladus.List.metainfo.xml.in.in
@@ -7,6 +7,8 @@
   <developer_name translatable="no">Vlad Krupinski</developer_name>
   <url type="homepage">https://github.com/mrvladus/Errands</url>
   <url type="bugtracker">https://github.com/mrvladus/Errands/issues</url>
+  <url type="vcs-browser">https://github.com/mrvladus/Errands/</url>
+  <url type="translate">https://github.com/mrvladus/Errands#translations</url>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">errands</translation>
   <custom>


### PR DESCRIPTION
### appdata: add vcs-browser and translate support

These URLs are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url
