### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/io.github.mrvladus.List.metainfo.xml.in.in
+++ b/data/io.github.mrvladus.List.metainfo.xml.in.in
@@ -12,10 +12,6 @@
   <url type="donation">https://github.com/mrvladus/Errands/blob/main/DONATIONS.md</url>
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">errands</translation>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
   <recommends>
     <control>touch</control>
     <control>keyboard</control>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work.

More information: https://github.com/ximion/appstream/issues/476