### PR TITLE
Add metainfo to the list of translatable files

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -11,3 +11,4 @@ errands/resources/ui/trash_item.ui
 
 # Data
 data/io.github.mrvladus.List.desktop.in.in
+data/io.github.mrvladus.List.metainfo.xml.in.in


### PR DESCRIPTION
This is split off from https://github.com/mrvladus/Errands/pull/77

I think it's useful for the AppStream metainfo file to be translated so that people who aren't as comfortable with English can still read about the app in their app store.

I admit that there isn't much worth translating in the gschema file currently.