### PR TITLE
Increase contrast for coloured tasks in dark mode

### DIFF
--- a/errands/resources/style-dark.css
+++ b/errands/resources/style-dark.css
@@ -4,31 +4,31 @@
 }
 
 .task-blue {
-    background: #7692b4;
+    background: #264770;
 }
 
 .task-green {
-    background: #5ca06b;
+    background: #345039;
 }
 
 .task-yellow {
-    background: #9b9542;
+    background: #5e5900;
 }
 
 .task-orange {
-    background: #bd9058;
+    background: #65461f;
 }
 
 .task-red {
-    background: #b74f43;
+    background: #5e0800;
 }
 
 .task-purple {
-    background: #a56ba5;
+    background: #5c395c;
 }
 
 .task-brown {
-    background: #9a826f;
+    background: #512e12;
 }
 
 link {


### PR DESCRIPTION
This merge request should hopefully reduce the poor colour contrast shown in Dark Mode. I've toned down the colours used in the style-dark.css so that they look less harsh, and they all either meet or exceed AAA contrast when checking with [this app.](https://flathub.org/apps/org.gnome.design.Contrast)
![image](https://github.com/mrvladus/Errands/assets/85719751/b960a900-1825-41d1-a6be-c1218784f4b1)

Compared to before:
![image](https://github.com/mrvladus/Errands/assets/85719751/e5a9668f-9635-41ab-9e15-da593367f691)

This should close #156. 