### PR TITLE
Use selection-mode for checkButton

### DIFF
--- a/errands/widgets/task.py
+++ b/errands/widgets/task.py
@@ -90,6 +90,7 @@ class Task(Gtk.Revealer):
         self.completed_btn = Gtk.CheckButton(
             valign="center",
             tooltip_text=_("Mark as Completed"),
+            css_classes=["selection-mode"],
         )
         self.completed_btn.connect("toggled", self.on_completed_btn_toggled)
         self.completed_btn.set_active(self.get_prop("completed"))


### PR DESCRIPTION
This makes the checkButton bigger, before it was easy to click on the task instead of the checkButton.
Great app, by the way!!!


![Screenshot from 2024-01-16 11-57-13](https://github.com/mrvladus/Errands/assets/44558032/23f932b5-e554-4180-859e-874ee8bb0dce)
