### PR TITLE
Update developer ID

### DIFF
--- a/data/io.github.mrvladus.List.metainfo.xml.in.in
+++ b/data/io.github.mrvladus.List.metainfo.xml.in.in
@@ -5,7 +5,7 @@
   <project_license>MIT</project_license>
   <content_rating type="oars-1.1" />
   <developer_name translatable="no">Vlad Krupinski</developer_name>
-  <developer id="github.com">
+  <developer id="io.github.mrvladus">
     <name translatable="no">Vlad Krupinski</name>
   </developer>
   <url type="homepage">https://github.com/mrvladus/Errands</url>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDds.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer