### PR TITLE
Fix duplicated tags from tasks

### DIFF
--- a/errands/lib/data.py
+++ b/errands/lib/data.py
@@ -385,9 +385,9 @@ class UserDataJSON:
         self.tags = new_tags
 
     def update_tags(self) -> None:
-        tasks_tags_texts: list[str] = []
+        tasks_tags_texts: set[str] = set()
         for task in self.tasks:
-            tasks_tags_texts.extend(task.tags)
+            tasks_tags_texts.update(task.tags)
 
         current_tags = self.tags
         current_tags_texts = [t.text for t in current_tags]


### PR DESCRIPTION
Without this change if there are more than one task with a tag that is not recodred in the database then the tag is duplicated.