### PR TITLE
Add again credit in translation removed in po/pt_BR.po

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the list package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # Vitor Gabriel Gomes <vitorgabrielgomesro9090@gmail.com>, 2023
+# Leandro Cunha <leandrocunha016@gmail.com>, 2023-2024
 # Gabriel de Moura <smolblackcat@proton.me>, 2024
 msgid ""
 msgstr ""


### PR DESCRIPTION
When carrying out translation, the conduct of removing credit in translation copyright is considered unethical and in this case I open a PULL REQUEST to insert it again. Thanks!