### PR TITLE
Don't use portal if not running under Flatpak

### DIFF
--- a/errands/application.py
+++ b/errands/application.py
@@ -103,30 +103,56 @@ class ErrandsApplication(Adw.Application):
         Log.debug("Application: Checking autostart")
 
         portal: Xdp.Portal = Xdp.Portal()
+        is_flatpak: bool = portal.running_under_flatpak()
 
-        # Request background
         if GSettings.get("launch-on-startup"):
-            portal.request_background(
-                None,
-                _("Errands need to run in the background for notifications"),
-                ["errands", "--gapplication-service"],
-                Xdp.BackgroundFlags.AUTOSTART,
-                None,
-                None,
-                None,
-            )
-        else:
-            try:
-                os.remove(
-                    os.path.join(
-                        GLib.get_home_dir(),
-                        ".config",
-                        "autostart",
-                        State.APP_ID + ".desktop",
-                    )
+            if is_flatpak:
+                # Request background
+                portal.request_background(
+                    None,
+                    _("Errands need to run in the background for notifications"),
+                    ["errands", "--gapplication-service"],
+                    Xdp.BackgroundFlags.AUTOSTART,
+                    None,
+                    None,
+                    None,
                 )
-            except Exception:
-                pass
+            else:
+                # Get or create autostart dir
+                autostart_dir: str = os.path.join(GLib.get_home_dir(), ".config", "autostart")
+                if not os.path.exists(autostart_dir):
+                    os.mkdir(autostart_dir)
+                autostart_file_content = f"""[Desktop Entry]
+Type=Application
+Name={State.APP_ID}
+Exec=errands --gapplication-service"""
+                # Create autostart file
+                file_path: str = os.path.join(autostart_dir, f"{State.APP_ID}.desktop")
+                with open(file_path, "w") as f:
+                    f.write(autostart_file_content)
+        else:
+            if is_flatpak:
+                portal.request_background(
+                    None,
+                    None,
+                    None,
+                    Xdp.BackgroundFlags.NONE,
+                    None,
+                    None,
+                    None,
+                )
+            else:
+                try:
+                    os.remove(
+                        os.path.join(
+                            GLib.get_home_dir(),
+                            ".config",
+                            "autostart",
+                            State.APP_ID + ".desktop",
+                        )
+                    )
+                except Exception:
+                    pass
 
     def do_startup(self) -> None:
         Adw.Application.do_startup(self)


### PR DESCRIPTION
It doesn't work properly without Flatpak, because it creates the file `~/.config/autostart/.desktop` (without the app ID).

Also, use portal to remove the autostart if running under Flatpak.