### PR TITLE
Fix setting accels

### DIFF
--- a/errands/widgets/window.py
+++ b/errands/widgets/window.py
@@ -145,11 +145,12 @@ class Window(Adw.ApplicationWindow):
         self.toast_overlay.add_toast(Adw.Toast.new(title=text))
 
     def _create_action(self, name: str, callback: callable, shortcuts=None) -> None:
+        app: Gio.Application = Gio.Application.get_default()
         action: Gio.SimpleAction = Gio.SimpleAction.new(name, None)
         action.connect("activate", callback)
         if shortcuts:
-            self.props.application.set_accels_for_action(f"app.{name}", shortcuts)
-        self.props.application.add_action(action)
+            app.set_accels_for_action(f"app.{name}", shortcuts)
+        app.add_action(action)
 
     def _create_actions(self) -> None:
         """


### PR DESCRIPTION
The application property is not ready during initialization.

This fixes the following error during application startup:
```python
Traceback (most recent call last):
  File "/usr/share/errands/errands/application.py", line 165, in do_startup
    State.main_window = Window(application=State.application)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/errands/errands/widgets/window.py", line 34, in __init__
    self._create_actions()
  File "/usr/share/errands/errands/widgets/window.py", line 221, in _create_actions
    self._create_action(
  File "/usr/share/errands/errands/widgets/window.py", line 151, in _create_action
    self.props.application.set_accels_for_action(f"app.{name}", shortcuts)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'set_accels_for_action'
```