### PR TITLE
Fix ical import allowing caldav==1.4.0

### DIFF
--- a/build-aux/requirements.txt
+++ b/build-aux/requirements.txt
@@ -1,4 +1,4 @@
-caldav==1.3.9
+caldav==1.4.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
 icalendar==5.0.12

--- a/errands/lib/sync/providers/caldav.py
+++ b/errands/lib/sync/providers/caldav.py
@@ -10,7 +10,7 @@ from typing import Any
 import urllib3
 import caldav
 from caldav import Calendar, DAVClient, Principal, Todo
-from caldav.elements import dav
+from caldav.elements import dav, ical
 
 from errands.lib.data import TaskData, TaskListData, UserData
 from errands.lib.gsettings import GSettings


### PR DESCRIPTION
Arch Linux bumped the python-caldav package to version 1.4.0. This change broke errands on this distribution. Instead of a normal caldav sync taking place, the following error message was displayed:
```
Exception in thread Thread-1 (sync):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/share/errands/errands/lib/sync/sync.py", line 53, in sync
    self.provider.sync()
  File "/usr/share/errands/errands/lib/sync/providers/caldav.py", line 215, in sync
    self.__sync_lists()
  File "/usr/share/errands/errands/lib/sync/providers/caldav.py", line 235, in __sync_lists
    self.__update_local_list(cal, list)
  File "/usr/share/errands/errands/lib/sync/providers/caldav.py", line 298, in __update_local_list
    color = cal.get_property(caldav.elements.ical.CalendarColor())
                             ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'caldav.elements' has no attribute 'ical'
```

A simple import fix seems to do the trick. I have not tested if this fix also supports caldav==1.3.9, but I can imagine that it does.

Off Topic: I use Errands daily because it seems to be the only caldav client supported on Linux that allows nested todos to be synchronized via caldav. I would like to thank the developers for their time. My live unironically depends on errands to some decree.
- Osh
