### PR TITLE
window: add F5 for sync

### DIFF
--- a/errands/widgets/window.py
+++ b/errands/widgets/window.py
@@ -226,7 +226,7 @@ class Window(Adw.ApplicationWindow):
         self._create_action("about", _about)
         self._create_action("import", _import, ["<primary>i"])
         self._create_action("quit", lambda *_: State.application.quit(), ["<primary>q"])
-        self._create_action("sync", _sync, ["<primary>f"])
+        self._create_action("sync", _sync, ["F5", "<primary>f"])
         self._create_action(
             "quit",
             lambda *_: self.props.application.quit(),


### PR DESCRIPTION
Adds F5 as a shortcut for syncing. This brings the application inline with other GNOME applications (such as [GNOME Calendar](https://gitlab.gnome.org/GNOME/gnome-calendar/-/blob/b6c383fa907eef6c16fd7c105ae3feddf608565d/src/gui/gtk/help-overlay.ui#L39)) and popular browsers. To avoid user confusion, the previous key bind is kept.


Also, what is the reason behind the two `quit` actions?