### PR TITLE
Add GNOME GitLab account to doap file

### DIFF
--- a/Errands.doap
+++ b/Errands.doap
@@ -21,6 +21,10 @@
             <foaf:accountServiceHomepage rdf:resource="https://github.com/"/>
             <foaf:accountName>mrvladus</foaf:accountName>
         </foaf:OnlineAccount>
+        <foaf:OnlineAccount>
+            <foaf:accountServiceHomepage rdf:resource="https://gitlab.gnome.org/"/>
+            <foaf:accountName>mrvladus</foaf:accountName>
+        </foaf:OnlineAccount>
       </foaf:account>
     </foaf:Person>
   </maintainer>


### PR DESCRIPTION
This enables the GNOME Circle team to send out automated notices on GitLab for issues that affect Errands.